### PR TITLE
Fix incompatible type warnings

### DIFF
--- a/lib/riffed/client.ex
+++ b/lib/riffed/client.ex
@@ -228,7 +228,8 @@ defmodule Riffed.Client do
             {new_client, exception}
           {:ok, rsp} ->
             {new_client, rsp}
-          other = {other, rsp} ->
+
+          other = {_, _} ->
             {new_client, other}
         end
       end


### PR DESCRIPTION
Fixes certain instances of this warning as of Elixir 1.11:
https://elixir-lang.org/blog/2020/10/06/elixir-v1-11-0-released/

```
warning: incompatible types:

    var7 !~ {var7, var8}

in expression:

    # lib/services/...
    other = {other, rsp}

where "other" was given the type {var7, var8} in:

    # lib/services/...
    other = {other, rsp}
```