### PR TITLE
Call struct values correctly to remove incompatible type warnings

### DIFF
--- a/lib/riffed/enumeration.ex
+++ b/lib/riffed/enumeration.ex
@@ -204,7 +204,7 @@ defmodule Riffed.Enumeration do
     enum_module = Module.concat(struct_module, conversion)
     quote do
       def to_erlang(enum=%unquote(enum_module){}, _) do
-        enum.value()
+        enum.value
       end
     end
   end
@@ -303,11 +303,11 @@ defmodule Riffed.Enumeration do
     fq_enum_name = Module.concat(container_module, enum_name)
     quote do
       def to_erlang(enum=%unquote(fq_enum_name){}, unquote(enum_alias)) do
-        enum.value()
+        enum.value
       end
 
       def to_erlang(enum=%unquote(fq_enum_name){}, _) do
-        enum.value()
+        enum.value
       end
     end
   end

--- a/lib/riffed/struct.ex
+++ b/lib/riffed/struct.ex
@@ -263,7 +263,7 @@ defmodule Riffed.Struct do
         quote do
           {unquote(name),
            unquote(dest_module).to_erlang(
-             s.unquote(field_variable)(), unquote(type_spec))
+             s.unquote(field_variable), unquote(type_spec))
           }
         end
       end)


### PR DESCRIPTION
Fix for additional `incompatible type` warnings.

In this case, we are always pattern matching for (and accessing values on) structs, so the `()` is unnecessary. 

```
warning: incompatible types:

    %Service.Model{} !~ atom()

in expression:

    # lib/services/...
    s.metric()

where "s" was given the type %Service.Model{} in:

    # lib/services/...
    s = %Service.Model{}

where "s" was given the type atom() (due to calling var.fun()) in:

    # lib/services/...
    s.metric()

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()
```